### PR TITLE
fix: clean excess pending orders to spec

### DIFF
--- a/BBGpp_Slim_AML.mq4
+++ b/BBGpp_Slim_AML.mq4
@@ -141,9 +141,18 @@ void OnTimer()
 
    int held=0,pending=0;
    CountOrders(held,pending);
-   if(held>=MaxUnits || pending>MaxUnits-held)
+   // 保有が上限に達した場合は保留を全取消
+   if(held>=MaxUnits)
      {
-      CancelPendingOrders(1);
+      if(pending>0) CancelPendingOrders(pending);
+      return;
+     }
+
+   int allowedPending = MaxUnits - held;
+   if(pending>allowedPending)
+     {
+      // 過剰な保留注文を一度に整理
+      CancelPendingOrders(pending-allowedPending);
       return;
      }
 


### PR DESCRIPTION
## Summary
- ensure pending grid orders never exceed allowed count

## Testing
- `wine metaeditor.exe /compile:BBGpp_Slim_AML.mq4` *(fails: wine32 missing / MetaEditor unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48d04091c8327a06640bf954147c9