### PR TITLE
Fix pending order cleanup to adhere to single-action loop

### DIFF
--- a/BBGpp_Slim_AML.mq4
+++ b/BBGpp_Slim_AML.mq4
@@ -141,18 +141,18 @@ void OnTimer()
 
    int held=0,pending=0;
    CountOrders(held,pending);
-   // 保有が上限に達した場合は保留を全取消
+   // 保有が上限に達した場合は保留を整理（1ループ1アクション）
    if(held>=MaxUnits)
      {
-      if(pending>0) CancelPendingOrders(pending);
+      if(pending>0) CancelPendingOrders();
       return;
      }
 
    int allowedPending = MaxUnits - held;
    if(pending>allowedPending)
      {
-      // 過剰な保留注文を一度に整理
-      CancelPendingOrders(pending-allowedPending);
+      // 過剰な保留注文を1件ずつ整理
+      CancelPendingOrders();
       return;
      }
 


### PR DESCRIPTION
## Summary
- Ensure pending order cleanup in OnTimer only cancels one order per loop to respect the single-action-per-loop requirement

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_68a48f1ea3908327be6691e281c7b615