### PR TITLE
CB計算の仕様準拠

### DIFF
--- a/BBGpp_Slim_AML.mq4
+++ b/BBGpp_Slim_AML.mq4
@@ -353,11 +353,12 @@ void RegisterClosure(int ticket,double spreadClose)
    if(!OrderSelect(ticket,SELECT_BY_TICKET,MODE_HISTORY)) return;
    double sc = spreadClose;
    if(sc<0) sc = lastSpreadPips;
-   double pv = MarketInfo(Symbol(),MODE_TICKVALUE) * Pip() / Point;
+   double pv   = MarketInfo(Symbol(),MODE_TICKVALUE) * Pip() / Point;
    double comm = MathAbs(OrderCommission());
-   cycleCost += (sc + 0.1) * pv + comm;
+   cycleCost  += (sc + 0.1) * pv + comm;
    double net = OrderProfit() + OrderSwap() + OrderCommission();
-   CycleBuffer += Tau_CB * net;
+   if(net>0)
+      CycleBuffer += Tau_CB * net;
    datetime ct = OrderCloseTime();
    if(ct>lastHistoryTime) lastHistoryTime = ct;
   }


### PR DESCRIPTION
## Summary
- CycleBufferが正の実現益に対してのみ加算されるよう修正

## Testing
- `make test` (エラー: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68a4a94e11a88327ba6e805aed4f832a